### PR TITLE
This fixes a warning during login when /bin/dash is /bin/sh

### DIFF
--- a/etc/profile.d/mate-qt.sh
+++ b/etc/profile.d/mate-qt.sh
@@ -1,5 +1,5 @@
 # MATE Desktop Qt integrations
-if [ "x$DESKTOP_SESSION" == "xmate" ] || [ "x$XDG_SESSION_DESKTOP" == "xmate" ]; then
+if [ "x$DESKTOP_SESSION" = "xmate" ] || [ "x$XDG_SESSION_DESKTOP" = "xmate" ]; then
     # QT apps to use GTK styling
     export QT_QPA_PLATFORMTHEME=gtk2
 fi


### PR DESCRIPTION
Problem:

dash does not support == as an operator for [ ], which in-turn causes
a warning about /etc/profile failing when starting up an X session.