### PR TITLE
Fix comparisons syntax

### DIFF
--- a/etc/X11/Xsession.d/80mate-environment
+++ b/etc/X11/Xsession.d/80mate-environment
@@ -1,5 +1,5 @@
 # This file is sourced by Xsession(5), not executed.
-if [ "x$DESKTOP_SESSION" == "xmate" ] || [ "x$XDG_SESSION_DESKTOP" == "xmate" ]; then
+if [ "x$DESKTOP_SESSION" = "xmate" ] || [ "x$XDG_SESSION_DESKTOP" = "xmate" ]; then
     # Ensure GTK accessibility modules are active.
     if [ -z "$GTK_MODULES" ]; then
         GTK_MODULES=gail:atk-bridge:canberra-gtk-module


### PR DESCRIPTION
Meanwhile some SHELLs would allow use of `==` instead of `=` others will stick
harder to origins and according to `man [`:

	STRING1 = STRING2
		the strings are equal

This is not purely academic nitpicking -- on Ubuntu 18.04.3 LTS I had
such errors in the ~/.xsession-errors which I tracked down to this very
file, for e. g.:

	/etc/X11/Xsession: 2: [: x: unexpected operator