### PR TITLE
Remove non-existent key 'idle-timeout' from slick-greeter schema override

### DIFF
--- a/usr/share/glib-2.0/schemas/30_ubuntu-mate.gschema.override
+++ b/usr/share/glib-2.0/schemas/30_ubuntu-mate.gschema.override
@@ -6,7 +6,6 @@ draw-user-backgrounds=false
 enable-hidpi='auto'
 font-name='Ubuntu 11'
 icon-theme-name='Yaru-MATE-dark'
-idle-timeout=300
 high-contrast=false
 #logo=Logo file to use
 onscreen-keyboard=false


### PR DESCRIPTION
UM iso builds show following error in the build logs.

> No such key “idle-timeout” in schema “x.dm.slick-greeter” as specified in override file `/usr/share/glib-2.0/schemas/30_ubuntu-mate.gschema.override`; ignoring override for this key.

It is also seen any time there is apt task triggers for `libglib2.0`.

Checked `/usr/share/glib-2.0/schemas/x.dm.slick-greeter.gschema.xml` file and confirmed the key 'idle-timeout' does not exist.